### PR TITLE
修复两个玩家同时发射火箭复制物品的bug

### DIFF
--- a/src/main/java/io/github/addoncommunity/galactifun/api/items/Rocket.java
+++ b/src/main/java/io/github/addoncommunity/galactifun/api/items/Rocket.java
@@ -150,6 +150,13 @@ public abstract class Rocket extends SlimefunItem implements RecipeDisplayItem {
         }, (player, destination) -> {
             player.closeInventory();
             int usedFuel = (int) Math.ceil(destination.distanceTo(currentWorld) / (DISTANCE_PER_FUEL * eff));
+
+            if (BSUtils.getStoredBoolean(b.getLocation(), "isLaunching")) {
+                p.sendMessage(ChatColor.RED + "火箭正在发射!");
+                return;
+            }
+            BSUtils.addBlockInfo(b.getLocation().getBlock(), "isLaunching", true);
+
             p.sendMessage(ChatColor.YELLOW + "请输入你要降落的坐标 <x> <z> (例如: -123 456) 或输入其他内容取消:");
             ChatUtils.awaitInput(p, s -> {
                 if (Util.COORD_PATTERN.matcher(s).matches()) {
@@ -182,6 +189,7 @@ public abstract class Rocket extends SlimefunItem implements RecipeDisplayItem {
                     }
                 } else {
                     p.sendMessage(ChatColor.RED + "已取消发射");
+                    BSUtils.addBlockInfo(b.getLocation().getBlock(), "isLaunching", false);
                 }
             });
         }).open(p);


### PR DESCRIPTION
## Changes
当玩家输入坐标时将火箭的状态设置为发射中，进入输入坐标状态前检测是否处于发射中，如果发射中则无法进入输入状态。

## Related Issues
Syntax: "利用火箭刷物品 https://github.com/SlimefunGuguProject/Galactifun/issues/29"

## Checklist
- [x] I have fully tested the proposed changes and promise that they will not break world generation, mob spawning, and the like.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
